### PR TITLE
Upgrade library dependencies

### DIFF
--- a/dropwizard-metrics-datadog/pom.xml
+++ b/dropwizard-metrics-datadog/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.github.flowcommerce</groupId>
         <artifactId>metrics-datadog-parent</artifactId>
-        <version>1.1.15</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/metrics-datadog/pom.xml
+++ b/metrics-datadog/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.github.flowcommerce</groupId>
         <artifactId>metrics-datadog-parent</artifactId>
-        <version>1.1.15</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -26,11 +26,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.datadoghq</groupId>
             <artifactId>java-dogstatsd-client</artifactId>
-            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -50,7 +50,6 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>dns-cache-manipulator</artifactId>
-            <version>1.8.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1,16 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <!--parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent-->
-
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.flowcommerce</groupId>
     <artifactId>metrics-datadog-parent</artifactId>
-    <version>1.1.15</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Datadog Metrics Parent</name>
     <description>A Datadog reporter for Coda Hale's Metrics</description>
@@ -61,9 +55,10 @@
         </contributor>
     </contributors>
     <properties>
-        <metrics.version>4.2.18</metrics.version>
-        <jackson.version>2.15.1</jackson.version>
-        <dropwizard.version>3.0.0</dropwizard.version>
+        <metrics.version>4.2.29</metrics.version>
+        <dogstatsd.version>4.4.3</dogstatsd.version>
+        <jackson.version>2.18.2</jackson.version>
+        <dropwizard.version>3.0.11</dropwizard.version>
     </properties>
     <build>
         <plugins>
@@ -157,11 +152,12 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
+                <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>com.datadoghq</groupId>
                 <artifactId>java-dogstatsd-client</artifactId>
-                <version>4.2.0</version>
+                <version>${dogstatsd.version}</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -178,13 +174,19 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>5.3.1</version>
+                <version>5.14.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
-                <version>2.0.7</version>
+                <version>2.0.16</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.alibaba</groupId>
+                <artifactId>dns-cache-manipulator</artifactId>
+                <version>1.8.3</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
* Upgrade to latest version of all 3rd party libraries
* Skip dropwizard upgrade to version 4.x due to missing javax.validation 
* Make jackson a compile-time only dependency and have the user supply the version
